### PR TITLE
Update plugin_ckeditor.py

### DIFF
--- a/modules/plugin_ckeditor.py
+++ b/modules/plugin_ckeditor.py
@@ -40,6 +40,7 @@ class CKEditor(object):
         self.settings.file_length_max = 10485760    # 10 MB
         self.settings.file_length_min = 0           # no minimum
         self.settings.spellcheck_while_typing = True
+        self.settings.toolbar = ''
 
         self.settings.download_url = download_url
         current.plugin_ckeditor = self
@@ -162,6 +163,8 @@ class CKEditor(object):
         scayt = 'false'
         if self.settings.spellcheck_while_typing:
             scayt = 'true'
+            
+        toolbar = self.settings.toolbar
 
         return XML(
             """
@@ -188,6 +191,7 @@ class CKEditor(object):
                             {name: 'paragraph', items: ['NumberedList', 'BulletedList', '-', 'Outdent', 'Indent', 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock']},
                         ],*/
                         scayt_autoStartup: %(scayt)s,
+                        toolbar: %(toolbar)s,
                     }
                 }
                 %(immediate)s
@@ -201,6 +205,7 @@ class CKEditor(object):
                 browse_url = browse_url,
                 scayt = scayt,
                 immediate = immediate,
+                toolbar = toolbar,
             )
         )
 


### PR DESCRIPTION
Make toolbar the different setting.

Somewhere in controller:
ckeditor.settings.toolbar = [...]

or better:
in ckeditor/config.js:

config.toolbar_basic = [  
        { name: 'links', items: [ 'Link', 'Unlink', 'Anchor' ] },  
        { name: 'basicstyles', items: [ 'Bold', 'Italic', 'Strike', '-', 'RemoveFormat' ] },
        { name: 'paragraph', items: [ 'NumberedList', 'BulletedList', '-', 'Outdent', 'Indent', '-', 'Blockquote' ] },
        { name: 'document', items: [ 'Source' ] },  
       ];

config.toolbar_advanced = [...]

in controller:
ckeditor.settings.toolbar = 'basic' (or 'advanced')
form = SQLFORM(...)

so we have different toolbars for different inputs.
empty value (default) does not affect.
